### PR TITLE
Bugfix ship_event and days_active

### DIFF
--- a/Model/Connect.php
+++ b/Model/Connect.php
@@ -267,6 +267,7 @@ class Connect extends \Magento\Payment\Model\Method\AbstractMethod
         $secondsCheck = $this->getConfigData('seconds_active', null, $order->getPayment()->getMethodInstance()->getCode());
         if (isset($secondsCheck)) {
             $secondsActive = $secondsCheck;
+            $daysActive = ""; //unset days_active if seconds_active is set
         } else {
             $secondsActive = "";
         }

--- a/etc/webapi_rest/events.xml
+++ b/etc/webapi_rest/events.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+  <event name="sales_order_shipment_save_after">
+    <observer name="msp_shipment_save_after" instance="MultiSafepay\Connect\Model\Observers\Shipment" />
+  </event>
+</config>


### PR DESCRIPTION
Fix PLGMAGTWO-134. Observe ship event when REST API is used to ship order.
As described in http://devdocs.magento.com/guides/v2.0/architecture/areas/areas.html

Fix PLGMAGTWO-137. Unset days_active when seconds_active is set.
"Days active will not be used when seconds active is configured" is noted in backend but not functional.