### PR TITLE
Expected identifier error in Internet Explorer 11

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/connect-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/connect-method.js
@@ -54,7 +54,7 @@ define(
         url,
         ui,
         modal,
-        ko,
+        ko
     ) {
         var configConnect = window.checkoutConfig.payment.connect;
         'use strict';


### PR DESCRIPTION
Payment methods are not loading in IE11.
Fix Expected identifier error in Internet Explorer.