### PR TITLE
Added htmlspecialchars to payment link

### DIFF
--- a/Model/Connect.php
+++ b/Model/Connect.php
@@ -595,7 +595,7 @@ class Connect extends \Magento\Payment\Model\Method\AbstractMethod
 
         //$this->logger->info(print_r($msporder, true));
         if ($this->_gatewayCode != "BANKTRANS") {
-            $order->addStatusToHistory($order->getStatus(), "User redirected to MultiSafepay" . '<br/>' . "Payment link:" . '<br/>' . $this->_client->orders->getPaymentLink(), false);
+            $order->addStatusToHistory($order->getStatus(), "User redirected to MultiSafepay" . '<br/>' . "Payment link:" . '<br/>' . htmlspecialchars($this->_client->orders->getPaymentLink()), false);
             $order->save();
         } else {
             $order->addStatusToHistory($order->getStatus(), "Banktransfer transaction started, waiting for payment", false);


### PR DESCRIPTION
Sometimes payment link has & char in it. 
then when on order detail page the comment is displayed with allowed tags it generates a the following message
DOMDocument::loadHTML(): htmlParseEntityRef: expecting ';' in Entity, line: 1

example order histroy message: "User redirected to MultiSafepay<br/>Payment link:<br/>https://bankieren.ideal.ing.nl/ideal/betalen/inlog-annuleren/static/detect_mob?trxid=xxxxxxxxxxxxxxxx&random=xxxxxxxxxxxxx"