### PR TITLE
Dispatch event before Transaction Request is sent

### DIFF
--- a/Model/Connect.php
+++ b/Model/Connect.php
@@ -606,7 +606,10 @@ class Connect extends \Magento\Payment\Model\Method\AbstractMethod
             $mspOrderDataObject = $this->dataOjbectFactory->create();
             $mspOrderDataObject->setMspOrderData($mspOrderData);
 
-            $this->eventManager->dispatch('before_send_msp_transaction_request', ['mspOrderData' => $mspOrderDataObject]);
+            $this->eventManager->dispatch(
+                'before_send_msp_transaction_request',
+                ['order' => $order, 'mspOrderData' => $mspOrderDataObject]
+            );
 
             $mspOrderData = $mspOrderDataObject->getMspOrderData();
 

--- a/Model/Connect.php
+++ b/Model/Connect.php
@@ -65,7 +65,6 @@ use MultiSafepay\Connect\Model\Api\MspClient;
 use MultiSafepay\Connect\Model\Config\Source\Creditcards;
 use MultiSafepay\Connect\Model\MultisafepayTokenizationFactory;
 use Magento\Framework\DataObjectFactory;
-use Magento\Framework\Event\ManagerInterface as EventManager;
 
 class Connect extends \Magento\Payment\Model\Method\AbstractMethod
 {


### PR DESCRIPTION
Hi guys,

This is a PR for [an issue](https://github.com/MultiSafepay/Magento2Msp/issues/8) that hasn't been fixed.

It basically dispatches an event that adds the array in an object in order to manipulate the data. 

This way we can change i.e. the description 

It would be really nice if this can be added to the core :) 

Thx in advance!
