### PR TITLE
Added execution of order_cancel_after event when cancelling the order.

### DIFF
--- a/Controller/Connect/Cancel.php
+++ b/Controller/Connect/Cancel.php
@@ -124,7 +124,9 @@ class Cancel extends \Magento\Framework\App\Action\Action
             //Cancel the order so a new one can created
             //You can disable the line below if you are using a fulfillment system that does not expect the order to be canceled,
             //but reopened again by second chance. Removing the line will keep the order pending. (PLGMAGTWOS-196)
-            $order->registerCancellation('Order canceled by customer')->save();
+            $order->registerCancellation('Order canceled by customer');
+            $this->_eventManager->dispatch('order_cancel_after', ['order' => $order]);
+            $order->save();
 
             $message = "The transaction was canceled or declined and the order was closed, please try again.";
 


### PR DESCRIPTION
When an order is cancelled in multisafepay, the order_cancel_after is not triggering which in turn causes some other modules not handing the order cancellation (properly).
This is likely done to circumvent the order service which calls "$this->getPayment()->cancel();". 
This commit adds manual dispatching of this event like $order->cancel() does.
